### PR TITLE
Allow usage of 1.0.0-dev branch of zend-expressive-authentication

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^7.1",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0.1",
-        "zendframework/zend-expressive-authentication": "^0.2 || ^1.0",
+        "zendframework/zend-expressive-authentication": "^0.2 || ^1.0.0-dev || ^1.0",
         "zendframework/zend-expressive-session": "^0.1.0"
     },
     "require-dev": {
@@ -44,7 +44,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev"
+            "dev-master": "1.0.x-dev"
         },
         "zf": {
             "config-provider": "Zend\\Expressive\\Authentication\\Session\\ConfigProvider"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "97e31d4eb68df0a5734e38ee10844b92",
+    "content-hash": "f677f73bade7f2a70902fdbc28392514",
     "packages": [
         {
             "name": "http-interop/http-middleware",
@@ -1846,7 +1846,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "zendframework/zend-expressive-authentication": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
The 1.0.0-dev branch of zend-expressive-authentication prepares for incorporation of PSR-15 interfaces; however, the API it exposes for adapters does not change.