### PR TITLE
Updated to zend-expressive-authentication 0.3 for UserInterface changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^7.1",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0.1",
-        "zendframework/zend-expressive-authentication": "^0.2 || ^1.0.0-dev || ^1.0",
+        "zendframework/zend-expressive-authentication": "^0.3 || ^1.0.0-dev || ^1.0",
         "zendframework/zend-expressive-session": "^0.1.0 || ^1.0.0-dev || ^1.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,78 +4,26 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "8202c174c984ec499c56e7d820b5f4d7",
+    "content-hash": "a8caac22dfa6bf6334bd1e848d234ce9",
     "packages": [
         {
-            "name": "http-interop/http-server-handler",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/http-interop/http-server-handler.git",
-                "reference": "931a6495fb1b6005c9b4abc4dd11fb12a2a8103b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/http-interop/http-server-handler/zipball/931a6495fb1b6005c9b4abc4dd11fb12a2a8103b",
-                "reference": "931a6495fb1b6005c9b4abc4dd11fb12a2a8103b",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.0",
-                "psr/http-message": "^1.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Interop\\Http\\Server\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for HTTP server-side request handler",
-            "keywords": [
-                "handler",
-                "http",
-                "psr",
-                "psr-15",
-                "psr-7",
-                "request",
-                "response",
-                "server"
-            ],
-            "time": "2017-11-09T18:35:22+00:00"
-        },
-        {
             "name": "http-interop/http-server-middleware",
-            "version": "1.0.1",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/http-interop/http-server-middleware.git",
-                "reference": "e605a7f47a002e857a3b9bb992010e2f859e4560"
+                "reference": "1ed99649e5f0d785c16d53cc021d7187ec350f28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/http-interop/http-server-middleware/zipball/e605a7f47a002e857a3b9bb992010e2f859e4560",
-                "reference": "e605a7f47a002e857a3b9bb992010e2f859e4560",
+                "url": "https://api.github.com/repos/http-interop/http-server-middleware/zipball/1ed99649e5f0d785c16d53cc021d7187ec350f28",
+                "reference": "1ed99649e5f0d785c16d53cc021d7187ec350f28",
                 "shasum": ""
             },
             "require": {
-                "http-interop/http-server-handler": "^1.0",
                 "php": ">=7.0",
-                "psr/http-message": "^1.0"
+                "psr/http-message": "^1.0",
+                "psr/http-server-middleware": "^1.0"
             },
             "replace": {
                 "http-interop/http-middleware": ">=0.5"
@@ -89,7 +37,10 @@
             "autoload": {
                 "psr-4": {
                     "Interop\\Http\\Server\\": "src/"
-                }
+                },
+                "files": [
+                    "src/alias.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -111,7 +62,8 @@
                 "request",
                 "response"
             ],
-            "time": "2017-11-09T21:42:30+00:00"
+            "abandoned": "psr/http-server-middleware",
+            "time": "2018-01-23T14:34:55+00:00"
         },
         {
             "name": "psr/container",
@@ -213,17 +165,123 @@
             "time": "2016-08-06T14:39:51+00:00"
         },
         {
+            "name": "psr/http-server-handler",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-server-handler.git",
+                "reference": "439d92054dc06097f2406ec074a2627839955a02"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-server-handler/zipball/439d92054dc06097f2406ec074a2627839955a02",
+                "reference": "439d92054dc06097f2406ec074a2627839955a02",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP server-side request handler",
+            "keywords": [
+                "handler",
+                "http",
+                "http-interop",
+                "psr",
+                "psr-15",
+                "psr-7",
+                "request",
+                "response",
+                "server"
+            ],
+            "time": "2018-01-22T17:04:15+00:00"
+        },
+        {
+            "name": "psr/http-server-middleware",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-server-middleware.git",
+                "reference": "ea17eb1fb2c8df6db919cc578451a8013c6a0ae5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-server-middleware/zipball/ea17eb1fb2c8df6db919cc578451a8013c6a0ae5",
+                "reference": "ea17eb1fb2c8df6db919cc578451a8013c6a0ae5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "psr/http-message": "^1.0",
+                "psr/http-server-handler": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP server-side middleware",
+            "keywords": [
+                "http",
+                "http-interop",
+                "middleware",
+                "psr",
+                "psr-15",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2018-01-22T17:08:31+00:00"
+        },
+        {
             "name": "zendframework/zend-expressive-authentication",
             "version": "dev-release-1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-authentication.git",
-                "reference": "a0cc1d4c8059f4deebe4d1f405e25c9803c2a49d"
+                "reference": "2145176ce76835c7d6aacf8ccd500698932d7daa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-authentication/zipball/a0cc1d4c8059f4deebe4d1f405e25c9803c2a49d",
-                "reference": "a0cc1d4c8059f4deebe4d1f405e25c9803c2a49d",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-authentication/zipball/2145176ce76835c7d6aacf8ccd500698932d7daa",
+                "reference": "2145176ce76835c7d6aacf8ccd500698932d7daa",
                 "shasum": ""
             },
             "require": {
@@ -272,7 +330,7 @@
                 "zend-expressive",
                 "zf"
             ],
-            "time": "2017-12-14T14:20:46+00:00"
+            "time": "2018-01-24T17:14:41+00:00"
         },
         {
             "name": "zendframework/zend-expressive-session",
@@ -1193,16 +1251,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "2.1.1",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "b11c729f95109b56a0fe9650c6a63a0fcd8c439f"
+                "reference": "11c07feade1d65453e06df3b3b90171d6d982087"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/b11c729f95109b56a0fe9650c6a63a0fcd8c439f",
-                "reference": "b11c729f95109b56a0fe9650c6a63a0fcd8c439f",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/11c07feade1d65453e06df3b3b90171d6d982087",
+                "reference": "11c07feade1d65453e06df3b3b90171d6d982087",
                 "shasum": ""
             },
             "require": {
@@ -1253,7 +1311,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2017-12-22T14:50:35+00:00"
+            "time": "2018-01-12T06:34:42+00:00"
         },
         {
             "name": "sebastian/diff",

--- a/test/PhpSessionTest.php
+++ b/test/PhpSessionTest.php
@@ -110,7 +110,7 @@ class PhpSessionTest extends TestCase
             'password' => 'bar'
         ]);
 
-        $this->authenticatedUser->getUsername()->willReturn('vimes');
+        $this->authenticatedUser->getIdentity()->willReturn('vimes');
         $this->authenticatedUser->getUserRoles()->willReturn(['captain']);
 
         $this->userRegister
@@ -154,7 +154,7 @@ class PhpSessionTest extends TestCase
             ->authenticate('foo', 'bar')
             ->will([$this->authenticatedUser, 'reveal']);
 
-        $this->authenticatedUser->getUsername()->willReturn('foo');
+        $this->authenticatedUser->getIdentity()->willReturn('foo');
         $this->authenticatedUser->getUserRoles()->willReturn([]);
 
         $phpSession = new PhpSession(
@@ -194,7 +194,7 @@ class PhpSessionTest extends TestCase
         $result = $phpSession->authenticate($this->request->reveal());
 
         $this->assertInstanceOf(UserInterface::class, $result);
-        $this->assertSame('vimes', $result->getUsername());
+        $this->assertSame('vimes', $result->getIdentity());
         $this->assertSame(['captain'], $result->getUserRoles());
     }
 


### PR DESCRIPTION
This PR updates the code using [zend-expressive-authentication](https://github.com/zendframework/zend-expressive-authentication/tree/0.3.0) v.0.3. This new version changed the `Zend\Expressive\Authentication\UserInterface` with PR https://github.com/zendframework/zend-expressive-authentication/pull/16.