### PR TITLE
Conflicting configuration with authentication attempt ...

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -22,8 +22,8 @@ class ConfigProvider
     public function getAuthenticationConfig() : array
     {
         return [
-            'username' => 'username', // provide a custom field name for the username
-            'password' => 'password', // provide a custom field name for the password
+            'username' => null, // provide a custom field name for the username
+            'password' => null, // provide a custom field name for the password
             'redirect' => '', // URI to which to redirect if no valid credentials present
         ];
     }

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -22,8 +22,8 @@ class ConfigProvider
     public function getAuthenticationConfig() : array
     {
         return [
-            'username' => '', // provide a custom field name for the username
-            'password' => '', // provide a custom field name for the password
+            'username' => 'username', // provide a custom field name for the username
+            'password' => 'password', // provide a custom field name for the password
             'redirect' => '', // URI to which to redirect if no valid credentials present
         ];
     }

--- a/test/PhpSessionTest.php
+++ b/test/PhpSessionTest.php
@@ -14,6 +14,7 @@ use Prophecy\Argument;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Expressive\Authentication\AuthenticationInterface;
+use Zend\Expressive\Authentication\Session\ConfigProvider;
 use Zend\Expressive\Authentication\Session\Exception;
 use Zend\Expressive\Authentication\Session\PhpSession;
 use Zend\Expressive\Authentication\UserInterface;
@@ -29,13 +30,14 @@ class PhpSessionTest extends TestCase
         $this->authenticatedUser = $this->prophesize(UserInterface::class);
         $this->responsePrototype = $this->prophesize(ResponseInterface::class);
         $this->session = $this->prophesize(SessionInterface::class);
+        $this->defaultConfig = (new ConfigProvider())()['authentication'];
     }
 
     public function testConstructor()
     {
         $phpSession = new PhpSession(
             $this->userRegister->reveal(),
-            [],
+            $this->defaultConfig,
             $this->responsePrototype->reveal()
         );
         $this->assertInstanceOf(AuthenticationInterface::class, $phpSession);
@@ -47,7 +49,7 @@ class PhpSessionTest extends TestCase
 
         $phpSession = new PhpSession(
             $this->userRegister->reveal(),
-            [],
+            $this->defaultConfig,
             $this->responsePrototype->reveal()
         );
 
@@ -64,7 +66,7 @@ class PhpSessionTest extends TestCase
 
         $phpSession = new PhpSession(
             $this->userRegister->reveal(),
-            [],
+            $this->defaultConfig,
             $this->responsePrototype->reveal()
         );
 
@@ -81,7 +83,7 @@ class PhpSessionTest extends TestCase
 
         $phpSession = new PhpSession(
             $this->userRegister->reveal(),
-            [],
+            $this->defaultConfig,
             $this->responsePrototype->reveal()
         );
 
@@ -119,7 +121,7 @@ class PhpSessionTest extends TestCase
 
         $phpSession = new PhpSession(
             $this->userRegister->reveal(),
-            [],
+            $this->defaultConfig,
             $this->responsePrototype->reveal()
         );
 
@@ -187,7 +189,7 @@ class PhpSessionTest extends TestCase
 
         $phpSession = new PhpSession(
             $this->userRegister->reveal(),
-            [],
+            $this->defaultConfig,
             $this->responsePrototype->reveal()
         );
 
@@ -212,7 +214,7 @@ class PhpSessionTest extends TestCase
 
         $phpSession = new PhpSession(
             $this->userRegister->reveal(),
-            [],
+            $this->defaultConfig,
             $this->responsePrototype->reveal()
         );
 


### PR DESCRIPTION
... at https://github.com/zendframework/zend-expressive-authentication-session/blob/master/src/PhpSession.php#L77

Because ConfigProvider gives default value of empty string, `$this->config['username'] ??` will never be false so if user omits that config key in their own configuration relying on those defaults in authenticator, the login process will never complete.

Alternative solution could be checking for empty trimmed string on top of key existence.

Provide a narrative description of what you are trying to accomplish:

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
rely on defaults in authentication, not configuring `username` and `password` in project's config provider
  - [x] Detail the original, incorrect behavior.
Login is rejected despite correct configuration
  - [x ] Detail the new, expected behavior.
Login should complete using defaults.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

- [x] Is this related to quality assurance?
Unit tests give false positive for default values that the package will actually be using.