### PR TITLE
add ^1.0.0alpha1 to require of expressive-authentication and expressive-session

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
         "php": "^7.1",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0.1",
-        "zendframework/zend-expressive-authentication": "^0.3 || ^1.0.0-dev || ^1.0",
-        "zendframework/zend-expressive-session": "^0.1.0 || ^1.0.0-dev || ^1.0"
+        "zendframework/zend-expressive-authentication": "^0.3 || ^1.0.0-dev || ^1.0.0alpha1 || ^1.0",
+        "zendframework/zend-expressive-session": "^0.1.0 || ^1.0.0-dev || ^1.0.0alpha1 || ^1.0"
     },
     "require-dev": {
         "phpspec/prophecy": "^1.7.2",


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
    composer require zendframework/zend-expressive-authentication-session:^1.0.0-dev
  - [x] Detail the original, incorrect behavior.
 I don't get latest `^1.0.0alpha1`of `zend-expressive-authentication` and `zend-expressive-session`
  - [x] Detail the new, expected behavior.
Register `zend-expressive-authentication` and `zend-expressive-session` to have `^1.0.0alpha1` value.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a `CHANGELOG.md` entry for the fix.
