### PR TITLE
ResponseFactory is passed to service instead of response prototype

### DIFF
--- a/src/PhpSession.php
+++ b/src/PhpSession.php
@@ -2,7 +2,7 @@
 /**
  * @see https://github.com/zendframework/zend-expressive-authentication-session
  *     for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license https://github.com/zendframework/zend-expressive-authentication-session/blob/master/LICENSE.md
  *     New BSD License
  */
@@ -33,25 +33,22 @@ class PhpSession implements AuthenticationInterface
     protected $config;
 
     /**
-     * @var ResponseInterface
+     * @var callable
      */
-    protected $responsePrototype;
+    protected $responseFactory;
 
-    /**
-     * Constructor
-     *
-     * @param UserRepositoryInterface $repository
-     * @param array $config
-     * @param ResponseInterface $responsePrototype
-     */
     public function __construct(
         UserRepositoryInterface $repository,
         array $config,
-        ResponseInterface $responsePrototype
+        callable $responseFactory
     ) {
         $this->repository = $repository;
         $this->config = $config;
-        $this->responsePrototype = $responsePrototype;
+
+        // Ensures type safety of the composed factory
+        $this->responseFactory = function () use ($responseFactory) : ResponseInterface {
+            return $responseFactory();
+        };
     }
 
     /**
@@ -96,12 +93,9 @@ class PhpSession implements AuthenticationInterface
         return $user;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function unauthorizedResponse(ServerRequestInterface $request): ResponseInterface
+    public function unauthorizedResponse(ServerRequestInterface $request) : ResponseInterface
     {
-        return $this->responsePrototype
+        return ($this->responseFactory)()
             ->withHeader(
                 'Location',
                 $this->config['redirect']

--- a/src/PhpSessionFactory.php
+++ b/src/PhpSessionFactory.php
@@ -2,7 +2,7 @@
 /**
  * @see https://github.com/zendframework/zend-expressive-authentication-session
  *     for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license https://github.com/zendframework/zend-expressive-authentication-session/blob/master/LICENSE.md
  *     New BSD License
  */
@@ -10,14 +10,12 @@
 namespace Zend\Expressive\Authentication\Session;
 
 use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
 use Zend\Expressive\Authentication\Exception;
-use Zend\Expressive\Authentication\ResponsePrototypeTrait;
 use Zend\Expressive\Authentication\UserRepositoryInterface;
 
 class PhpSessionFactory
 {
-    use ResponsePrototypeTrait;
-
     public function __invoke(ContainerInterface $container): PhpSession
     {
         $userRegister = $container->has(UserRepositoryInterface::class)
@@ -41,7 +39,7 @@ class PhpSessionFactory
         return new PhpSession(
             $userRegister,
             $config,
-            $this->getResponsePrototype($container)
+            $container->get(ResponseInterface::class)
         );
     }
 }

--- a/test/PhpSessionTest.php
+++ b/test/PhpSessionTest.php
@@ -35,8 +35,14 @@ class PhpSessionTest extends TestCase
     /** @var ResponseInterface|ObjectProphecy */
     private $responsePrototype;
 
+    /** @var callable */
+    private $responseFactory;
+
     /** @var SessionInterface|ObjectProphecy */
     private $session;
+
+    /** @var array */
+    private $defaultConfig;
 
     protected function setUp()
     {
@@ -44,6 +50,9 @@ class PhpSessionTest extends TestCase
         $this->userRegister = $this->prophesize(UserRepositoryInterface::class);
         $this->authenticatedUser = $this->prophesize(UserInterface::class);
         $this->responsePrototype = $this->prophesize(ResponseInterface::class);
+        $this->responseFactory = function () {
+            return $this->responsePrototype->reveal();
+        };
         $this->session = $this->prophesize(SessionInterface::class);
         $this->defaultConfig = (new ConfigProvider())()['authentication'];
     }
@@ -53,7 +62,7 @@ class PhpSessionTest extends TestCase
         $phpSession = new PhpSession(
             $this->userRegister->reveal(),
             $this->defaultConfig,
-            $this->responsePrototype->reveal()
+            $this->responseFactory
         );
         $this->assertInstanceOf(AuthenticationInterface::class, $phpSession);
     }
@@ -65,7 +74,7 @@ class PhpSessionTest extends TestCase
         $phpSession = new PhpSession(
             $this->userRegister->reveal(),
             $this->defaultConfig,
-            $this->responsePrototype->reveal()
+            $this->responseFactory
         );
 
         $this->expectException(Exception\MissingSessionContainerException::class);
@@ -82,7 +91,7 @@ class PhpSessionTest extends TestCase
         $phpSession = new PhpSession(
             $this->userRegister->reveal(),
             $this->defaultConfig,
-            $this->responsePrototype->reveal()
+            $this->responseFactory
         );
 
         $this->assertNull($phpSession->authenticate($this->request->reveal()));
@@ -99,7 +108,7 @@ class PhpSessionTest extends TestCase
         $phpSession = new PhpSession(
             $this->userRegister->reveal(),
             $this->defaultConfig,
-            $this->responsePrototype->reveal()
+            $this->responseFactory
         );
 
         $this->assertNull($phpSession->authenticate($this->request->reveal()));
@@ -137,7 +146,7 @@ class PhpSessionTest extends TestCase
         $phpSession = new PhpSession(
             $this->userRegister->reveal(),
             $this->defaultConfig,
-            $this->responsePrototype->reveal()
+            $this->responseFactory
         );
 
         $result = $phpSession->authenticate($this->request->reveal());
@@ -180,7 +189,7 @@ class PhpSessionTest extends TestCase
                 'username' => 'user',
                 'password' => 'pass',
             ],
-            $this->responsePrototype->reveal()
+            $this->responseFactory
         );
 
         $result = $phpSession->authenticate($this->request->reveal());
@@ -205,7 +214,7 @@ class PhpSessionTest extends TestCase
         $phpSession = new PhpSession(
             $this->userRegister->reveal(),
             $this->defaultConfig,
-            $this->responsePrototype->reveal()
+            $this->responseFactory
         );
 
         $result = $phpSession->authenticate($this->request->reveal());
@@ -230,7 +239,7 @@ class PhpSessionTest extends TestCase
         $phpSession = new PhpSession(
             $this->userRegister->reveal(),
             $this->defaultConfig,
-            $this->responsePrototype->reveal()
+            $this->responseFactory
         );
 
         $this->assertNull($phpSession->authenticate($this->request->reveal()));
@@ -251,7 +260,7 @@ class PhpSessionTest extends TestCase
         $phpSession = new PhpSession(
             $this->userRegister->reveal(),
             [ 'redirect' => '/login' ],
-            $this->responsePrototype->reveal()
+            $this->responseFactory
         );
 
         $result = $phpSession->unauthorizedResponse($this->request->reveal());


### PR DESCRIPTION
Before the response prototype was passed to the service so the second
fetch of the service used the same response.
The brand new response should be created each time the service is used.

Ref:
- https://github.com/zendframework/zend-expressive-authentication-oauth2/issues/16#issuecomment-368691028
- https://github.com/zendframework/zend-expressive-authentication/pull/19