### PR TITLE
Remove default config and enable config redirect exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,39 @@ Run the following to install this library:
 $ composer require zendframework/zend-expressive-authentication-session
 ```
 
+## Configuration
+
+```php
+<?php
+
+declare(strict_types=1);
+
+//use App\Infrastructure\Repository\UserRepository;
+//use App\Infrastructure\Repository\UserRepositoryFactory;
+use Zend\Expressive\Authentication\AuthenticationInterface;
+use Zend\Expressive\Authentication\Session\PhpSession;
+use Zend\Expressive\Authentication\UserRepositoryInterface;
+
+return [
+    'dependencies' => [
+        'aliases' => [
+            AuthenticationInterface::class => PhpSession::class,
+            UserRepositoryInterface::class => UserRepository::class,
+        ],
+
+        'factories' => [
+            UserRepository::class => UserRepositoryFactory::class,
+        ],
+    ],
+
+    'authentication' => [
+        'username' => null, // provide a custom field name for the username
+        'password' => null, // provide a custom field name for the password
+        'redirect' => '', // URI to which to redirect if no valid credentials present
+    ],
+];
+```
+
 ## Documentation
 
 Documentation is [in the doc tree](docs/book/), and can be compiled using [mkdocs](http://www.mkdocs.org):

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ return [
     'authentication' => [
         'username' => null, // provide a custom field name for the username
         'password' => null, // provide a custom field name for the password
-        'redirect' => '', // URI to which to redirect if no valid credentials present
+        'redirect' => '/login', // URI to which to redirect if no valid credentials present
     ],
 ];
 ```

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -22,9 +22,8 @@ class ConfigProvider
     public function getAuthenticationConfig() : array
     {
         return [
-            'username' => null, // provide a custom field name for the username
-            'password' => null, // provide a custom field name for the password
-            'redirect' => '', // URI to which to redirect if no valid credentials present
+            'username' => null,
+            'password' => null,
         ];
     }
 


### PR DESCRIPTION
This PR removes the default redirect config to force users to set it. Without the config redirect exception is never thrown and you spend precious time searching for redirects to the same page.

Fixes #13 

Can't really add tests for this.