### PR TITLE
Prepare for a stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 1.0.0 - TBD
+
+### Added
+
+- [#19](https://github.com/zendframework/zend-expressive-authentication-session/pull/19) adds comprehensive documentation detailing usage and configuration
+  of the package.
+
+### Changed
+
+- [#19](https://github.com/zendframework/zend-expressive-authentication-session/pull/19) updates the package to depend on zend-expressive-authentication
+  1.0.0 instead of a pre-release version.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 0.5.0 - 2018-06-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,51 +15,6 @@ Run the following to install this library:
 $ composer require zendframework/zend-expressive-authentication-session
 ```
 
-## Configuration
-
-You will need to provide configuration for this module to work correctly. The
-following demonstrates:
-
-- Mapping a custom `UserRepositoryInterface` implementation for use as a backend
-  to the functionality this authentication adapter provides.
-- Mapping the `PhpSession` adapter as the `AuthenticationInterface`
-  implementation to use in your application.
-- Providing configuration for this adapter, including custom field names for the
-  username and password, as well as a path in the application to which to redirect
-  when no valid credentials are present.
-
-```php
-<?php
-// in a config/autoload/*.global.php file:
-
-declare(strict_types=1);
-
-//use App\Infrastructure\Repository\UserRepository;
-//use App\Infrastructure\Repository\UserRepositoryFactory;
-use Zend\Expressive\Authentication\AuthenticationInterface;
-use Zend\Expressive\Authentication\Session\PhpSession;
-use Zend\Expressive\Authentication\UserRepositoryInterface;
-
-return [
-    'dependencies' => [
-        'aliases' => [
-            AuthenticationInterface::class => PhpSession::class,
-            UserRepositoryInterface::class => UserRepository::class,
-        ],
-
-        'factories' => [
-            UserRepository::class => UserRepositoryFactory::class,
-        ],
-    ],
-
-    'authentication' => [
-        'username' => null, // provide a custom field name for the username
-        'password' => null, // provide a custom field name for the password
-        'redirect' => '/login', // URI to which to redirect if no valid credentials present
-    ],
-];
-```
-
 ## Documentation
 
 Documentation is [in the doc tree](docs/book/), and can be compiled using [mkdocs](http://www.mkdocs.org):

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^7.1",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0.1",
-        "zendframework/zend-expressive-authentication": "^0.5.0",
+        "zendframework/zend-expressive-authentication": "^1.0",
         "zendframework/zend-expressive-session": "^1.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ea06a9e0cb3dd8e80da1e8114ecad1dd",
+    "content-hash": "a8c8443e678953e4f15c1bc58fca807b",
     "packages": [
         {
             "name": "psr/container",
@@ -213,16 +213,16 @@
         },
         {
             "name": "zendframework/zend-expressive-authentication",
-            "version": "0.5.0",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-authentication.git",
-                "reference": "486cb20dc81df864ee4706e8d191fc87ad0af91b"
+                "reference": "52594067ffc149cd7defb87388e2c33707b5203f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-authentication/zipball/486cb20dc81df864ee4706e8d191fc87ad0af91b",
-                "reference": "486cb20dc81df864ee4706e8d191fc87ad0af91b",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-authentication/zipball/52594067ffc149cd7defb87388e2c33707b5203f",
+                "reference": "52594067ffc149cd7defb87388e2c33707b5203f",
                 "shasum": ""
             },
             "require": {
@@ -274,20 +274,20 @@
                 "zend-expressive",
                 "zf"
             ],
-            "time": "2018-05-23T16:58:27+00:00"
+            "time": "2018-08-27T15:09:06+00:00"
         },
         {
             "name": "zendframework/zend-expressive-session",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-session.git",
-                "reference": "632fba38f01e884bb788ac3baf529d41458d75a4"
+                "reference": "1bcb8e7869b47e30f1ba692f15e52481d1d550db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-session/zipball/632fba38f01e884bb788ac3baf529d41458d75a4",
-                "reference": "632fba38f01e884bb788ac3baf529d41458d75a4",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-session/zipball/1bcb8e7869b47e30f1ba692f15e52481d1d550db",
+                "reference": "1bcb8e7869b47e30f1ba692f15e52481d1d550db",
                 "shasum": ""
             },
             "require": {
@@ -310,8 +310,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev",
-                    "dev-develop": "1.1.x-dev"
+                    "dev-master": "1.1.x-dev",
+                    "dev-develop": "1.2.x-dev"
                 },
                 "zf": {
                     "config-provider": "Zend\\Expressive\\Session\\ConfigProvider"
@@ -336,7 +336,7 @@
                 "zend-expressive",
                 "zf"
             ],
-            "time": "2018-03-15T14:36:37+00:00"
+            "time": "2018-09-12T15:16:19+00:00"
         }
     ],
     "packages-dev": [
@@ -396,25 +396,28 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.7.0",
+            "version": "1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
+                "reference": "3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8",
+                "reference": "3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.1"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
             },
             "require-dev": {
                 "doctrine/collections": "^1.0",
                 "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^4.1"
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "autoload": {
@@ -437,26 +440,26 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-10-19T19:58:43+00:00"
+            "time": "2018-06-11T23:09:50+00:00"
         },
         {
             "name": "phar-io/manifest",
-            "version": "1.0.1",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-phar": "*",
-                "phar-io/version": "^1.0.1",
+                "phar-io/version": "^2.0",
                 "php": "^5.6 || ^7.0"
             },
             "type": "library",
@@ -492,20 +495,20 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2017-03-05T18:14:27+00:00"
+            "time": "2018-07-08T19:23:20+00:00"
         },
         {
             "name": "phar-io/version",
-            "version": "1.0.1",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6",
                 "shasum": ""
             },
             "require": {
@@ -539,7 +542,7 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
-            "time": "2017-03-05T17:38:23+00:00"
+            "time": "2018-07-08T19:19:57+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -695,16 +698,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.7.6",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712"
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
-                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
                 "shasum": ""
             },
             "require": {
@@ -716,12 +719,12 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7.x-dev"
+                    "dev-master": "1.8.x-dev"
                 }
             },
             "autoload": {
@@ -754,27 +757,27 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-04-18T13:57:24+00:00"
+            "time": "2018-08-05T17:53:17+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "6.0.5",
+            "version": "6.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "4cab20a326d14de7575a8e235c70d879b569a57a"
+                "reference": "865662550c384bc1db7e51d29aeda1c2c161d69a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/4cab20a326d14de7575a8e235c70d879b569a57a",
-                "reference": "4cab20a326d14de7575a8e235c70d879b569a57a",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/865662550c384bc1db7e51d29aeda1c2c161d69a",
+                "reference": "865662550c384bc1db7e51d29aeda1c2c161d69a",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
                 "php": "^7.1",
-                "phpunit/php-file-iterator": "^1.4.2",
+                "phpunit/php-file-iterator": "^2.0",
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-token-stream": "^3.0",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
@@ -817,29 +820,32 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-05-28T11:49:20+00:00"
+            "time": "2018-06-01T07:51:50+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.5",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
+                "reference": "050bedf145a257b1ff02746c31894800e5122946"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/050bedf145a257b1ff02746c31894800e5122946",
+                "reference": "050bedf145a257b1ff02746c31894800e5122946",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -854,7 +860,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -864,7 +870,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2017-11-27T13:52:08+00:00"
+            "time": "2018-09-13T20:33:42+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1007,34 +1013,34 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.1.5",
+            "version": "7.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "ca64dba53b88aba6af32aebc6b388068db95c435"
+                "reference": "7b331efabbb628c518c408fdfcaf571156775de2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ca64dba53b88aba6af32aebc6b388068db95c435",
-                "reference": "ca64dba53b88aba6af32aebc6b388068db95c435",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/7b331efabbb628c518c408fdfcaf571156775de2",
+                "reference": "7b331efabbb628c518c408fdfcaf571156775de2",
                 "shasum": ""
             },
             "require": {
+                "doctrine/instantiator": "^1.1",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "^1.6.1",
-                "phar-io/manifest": "^1.0.1",
-                "phar-io/version": "^1.0",
+                "myclabs/deep-copy": "^1.7",
+                "phar-io/manifest": "^1.0.2",
+                "phar-io/version": "^2.0",
                 "php": "^7.1",
                 "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^6.0.1",
-                "phpunit/php-file-iterator": "^1.4.3",
+                "phpunit/php-code-coverage": "^6.0.7",
+                "phpunit/php-file-iterator": "^2.0.1",
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-timer": "^2.0",
-                "phpunit/phpunit-mock-objects": "^6.1.1",
                 "sebastian/comparator": "^3.0",
                 "sebastian/diff": "^3.0",
                 "sebastian/environment": "^3.1",
@@ -1044,10 +1050,14 @@
                 "sebastian/resource-operations": "^1.0",
                 "sebastian/version": "^2.0.1"
             },
+            "conflict": {
+                "phpunit/phpunit-mock-objects": "*"
+            },
             "require-dev": {
                 "ext-pdo": "*"
             },
             "suggest": {
+                "ext-soap": "*",
                 "ext-xdebug": "*",
                 "phpunit/php-invoker": "^2.0"
             },
@@ -1057,7 +1067,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.1-dev"
+                    "dev-master": "7.3-dev"
                 }
             },
             "autoload": {
@@ -1083,63 +1093,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-04-29T15:09:19+00:00"
-        },
-        {
-            "name": "phpunit/phpunit-mock-objects",
-            "version": "6.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "70c740bde8fd9ea9ea295be1cd875dd7b267e157"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/70c740bde8fd9ea9ea295be1cd875dd7b267e157",
-                "reference": "70c740bde8fd9ea9ea295be1cd875dd7b267e157",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.0.5",
-                "php": "^7.1",
-                "phpunit/php-text-template": "^1.2.1",
-                "sebastian/exporter": "^3.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.0"
-            },
-            "suggest": {
-                "ext-soap": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "6.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Mock Object library for PHPUnit",
-            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
-            "keywords": [
-                "mock",
-                "xunit"
-            ],
-            "time": "2018-04-11T04:50:36+00:00"
+            "time": "2018-09-08T15:14:29+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1188,16 +1142,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "3.0.0",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "ed5fd2281113729f1ebcc64d101ad66028aeb3d5"
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/ed5fd2281113729f1ebcc64d101ad66028aeb3d5",
-                "reference": "ed5fd2281113729f1ebcc64d101ad66028aeb3d5",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
                 "shasum": ""
             },
             "require": {
@@ -1248,20 +1202,20 @@
                 "compare",
                 "equality"
             ],
-            "time": "2018-04-18T13:33:00+00:00"
+            "time": "2018-07-12T15:12:46+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "e09160918c66281713f1c324c1f4c4c3037ba1e8"
+                "reference": "366541b989927187c4ca70490a35615d3fef2dce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/e09160918c66281713f1c324c1f4c4c3037ba1e8",
-                "reference": "e09160918c66281713f1c324c1f4c4c3037ba1e8",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/366541b989927187c4ca70490a35615d3fef2dce",
+                "reference": "366541b989927187c4ca70490a35615d3fef2dce",
                 "shasum": ""
             },
             "require": {
@@ -1304,7 +1258,7 @@
                 "unidiff",
                 "unified diff"
             ],
-            "time": "2018-02-01T13:45:15+00:00"
+            "time": "2018-06-10T07:54:39+00:00"
         },
         {
             "name": "sebastian/environment",

--- a/docs/book/intro.md
+++ b/docs/book/intro.md
@@ -1,52 +1,6 @@
-# zend-expressive-authentication-session
-
-This library provides a [zend-expressive-authentication](https://github.com/zendframework/zend-expressive-authentication/)
-adapter that handles form-based username/password authentication credentials
-where the user details are subsequently stored in a session.
-
-Documentation forthcoming...
-
-## Configuration
-
-You will need to provide configuration for this module to work correctly. The
-following demonstrates:
-
-- Mapping a custom `UserRepositoryInterface` implementation for use as a backend
-  to the functionality this authentication adapter provides.
-- Mapping the `PhpSession` adapter as the `AuthenticationInterface`
-  implementation to use in your application.
-- Providing configuration for this adapter, including custom field names for the
-  username and password, as well as a path in the application to which to redirect
-  when no valid credentials are present.
-
-```php
-<?php
-// in a config/autoload/*.global.php file:
-
-declare(strict_types=1);
-
-//use App\Infrastructure\Repository\UserRepository;
-//use App\Infrastructure\Repository\UserRepositoryFactory;
-use Zend\Expressive\Authentication\AuthenticationInterface;
-use Zend\Expressive\Authentication\Session\PhpSession;
-use Zend\Expressive\Authentication\UserRepositoryInterface;
-
-return [
-    'dependencies' => [
-        'aliases' => [
-            AuthenticationInterface::class => PhpSession::class,
-            UserRepositoryInterface::class => UserRepository::class,
-        ],
-
-        'factories' => [
-            UserRepository::class => UserRepositoryFactory::class,
-        ],
-    ],
-
-    'authentication' => [
-        'username' => null, // provide a custom field name for the username
-        'password' => null, // provide a custom field name for the password
-        'redirect' => '/login', // URI to which to redirect if no valid credentials present
-    ],
-];
-```
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive-authentication-session/v1/intro/"></noscript>
+<script>
+  document.addEventListener("DOMContentLoaded", function (event) {
+    window.location.pathname = '/zend-expressive-authentication-session/v1/intro/';
+  });
+</script>

--- a/docs/book/v1/config.md
+++ b/docs/book/v1/config.md
@@ -1,0 +1,65 @@
+# Configuration
+
+You will need to provide configuration for the adapter to work correctly:
+
+- You will need to alias the zend-expressive-authentication
+  `AuthenticationInterface` to the package's `PhpSession` implementation.
+
+- You will need to ensure a zend-expressive-authentication
+  `UserRepositoryInterface` implementation is available and configured.
+
+- You will need to provide a factory capable of generating a `UserInterface`
+  instance, if you do not want to use the default provided by
+  zend-expressive-authentication.
+
+- You will need to provide a URL or path to which the authentication middleware
+  will **redirect** if no user is discovered in the session.
+
+## Example
+
+Below is an example demonstrating authentication configuration you might provide
+when using zend-expressive-authentication-session. In particular:
+
+- It aliases the `PdoDatabase` user repository implementation from
+  zend-expressive-authentication as the `UserRepositoryInterface` service.
+
+- It maps the `PhpSession` adapter from this package as the
+  `AuthenticationInterface` implementation.
+
+- It **does not** configure a `Zend\Expressive\Authentication\UserInterface`
+  service, opting to use the default provided by zend-expressive-authentication.
+
+- It configures the path `/login` as the redirect URL to which unauthenticated
+  users will be redirected.
+
+
+```php
+<?php
+// in a config/autoload/*.global.php file:
+
+declare(strict_types=1);
+
+use Zend\Expressive\Authentication\AuthenticationInterface;
+use Zend\Expressive\Authentication\Session\PhpSession;
+use Zend\Expressive\Authentication\UserRepositoryInterface;
+use Zend\Expressive\Authentication\UserRepository\PdoDatabase;
+
+return [
+    'dependencies' => [
+        'aliases' => [
+            AuthenticationInterface::class => PhpSession::class,
+            UserRepositoryInterface::class => PdoDatabase::class,
+        ],
+    ],
+
+    'authentication' => [
+        'redirect' => '/login',
+    ],
+];
+```
+
+## Handling the login
+
+Once you have configured the adapter, you will also need to write a handler that
+will handle login attempts; [see the next section for details on how to
+accomplish that](login-handler.md).

--- a/docs/book/v1/config.md
+++ b/docs/book/v1/config.md
@@ -23,14 +23,14 @@ when using zend-expressive-authentication-session. In particular:
 - It aliases the `PdoDatabase` user repository implementation from
   zend-expressive-authentication as the `UserRepositoryInterface` service.
 
-- It maps the `PhpSession` adapter from this package as the
-  `AuthenticationInterface` implementation.
+- It aliases the `PhpSession` adapter from this package to the
+  `AuthenticationInterface` service.
 
 - It **does not** configure a `Zend\Expressive\Authentication\UserInterface`
   service, opting to use the default provided by zend-expressive-authentication.
 
-- It configures the path `/login` as the redirect URL to which unauthenticated
-  users will be redirected.
+- It configures the path `/login` as the URL to which unauthenticated users will
+  be redirected.
 
 
 ```php
@@ -59,6 +59,5 @@ return [
 
 ## Handling the login
 
-Once you have configured the adapter, you will also need to write a handler that
-will handle login attempts; [see the next section for details on how to
-accomplish that](login-handler.md).
+Once you have configured the adapter, [you will also need to write a handler that
+will handle login attempts](login-handler.md).

--- a/docs/book/v1/config.md
+++ b/docs/book/v1/config.md
@@ -34,7 +34,6 @@ when using zend-expressive-authentication-session. In particular:
 
 
 ```php
-<?php
 // in a config/autoload/*.global.php file:
 
 declare(strict_types=1);

--- a/docs/book/v1/intro.md
+++ b/docs/book/v1/intro.md
@@ -1,7 +1,7 @@
 # zend-expressive-authentication-session
 
-This library provides a [zend-expressive-authentication](https://github.com/zendframework/zend-expressive-authentication/)
-adapter that handles form-based username/password authentication credentials
+This library provides a [zend-expressive-authentication adapter](https://docs.zendframework.com/zend-expressive-authentication//v1/auth-adapter/)
+that handles form-based username/password authentication credentials
 where the user details are subsequently stored in a session.
 
 When a user who has not previously authenticated hits the middleware, it will
@@ -9,5 +9,5 @@ redirect to a page asking for their credentials, as a username/password
 combination. When they submit this page with valid credentials, the adapter
 will store user information (which mimimally includes the username, but can also
 include authorization roles and other information). Subsequent requests hitting
-the authentication middleware will then pull the user date from the session,
+the authentication middleware will then pull the user data from the session,
 marking the user as authenticated.

--- a/docs/book/v1/intro.md
+++ b/docs/book/v1/intro.md
@@ -1,0 +1,13 @@
+# zend-expressive-authentication-session
+
+This library provides a [zend-expressive-authentication](https://github.com/zendframework/zend-expressive-authentication/)
+adapter that handles form-based username/password authentication credentials
+where the user details are subsequently stored in a session.
+
+When a user who has not previously authenticated hits the middleware, it will
+redirect to a page asking for their credentials, as a username/password
+combination. When they submit this page with valid credentials, the adapter
+will store user information (which mimimally includes the username, but can also
+include authorization roles and other information). Subsequent requests hitting
+the authentication middleware will then pull the user date from the session,
+marking the user as authenticated.

--- a/docs/book/v1/login-handler.md
+++ b/docs/book/v1/login-handler.md
@@ -52,7 +52,7 @@ or updated:
 
 We will now edit the template. The main considerations are:
 
-- It needs to have a form that submits back to a URL provided to the template.
+- It needs to have a form that submits back to the login page.
 - The form needs both a `username` and a `password` field.
 
 Our application is built off the skeleton, and so we are currently using
@@ -63,7 +63,7 @@ PlatesPHP as noted earlier. As such, we will update the template in
 ```php
 <div class="container">
     <div class="row">
-        <div class="col-sm"><form action="<?= $action ?>" method="post">
+        <div class="col-sm"><form action="<?= $this->url('login') ?>" method="post">
             <div class="form-group">
                 <label for="username">Username</label>
                 <input type="text" class="form-control" id="username" name="username" placeholder="Enter username">
@@ -80,6 +80,14 @@ PlatesPHP as noted earlier. As such, we will update the template in
 
 ## Complete the handler
 
+Our handler will react to two different HTTP methods. For an initial login
+request, the `GET` method will be used, and we will need to display our
+template. When the user submits the form, it will be via the `POST` method. In
+this situation, if the credentials are invalid, the `PhpSession` adapter will
+redirect to the login page again, via a `GET`. However, if it is successful, it
+will continue to the handler; at this point, we will want to redirect to the
+original page that needed an authenticated user.
+
 The generated handler will mostly work for our needs. However, we need to modify
 it to do the following:
 
@@ -88,8 +96,16 @@ it to do the following:
 - If one is not available:
   - Check the `Referer` request header
   - If the header is empty, or points to the login page, use the home page.
-  - Store the value in the session.
-- Pass the redirect URI to the template engine.
+- If this is a POST request:
+  - Remove the redirect URI from the session.
+  - Redirect to the redirect URI.
+- If this is a GET request:
+  - Store the redirect URI in the session.
+  - Pass the redirect URI to the template engine.
+
+Since we will be performing a redirect for successful POST requests, we will
+need to add a requirement on `Zend\Diactoros\Response\RedirectResponse` in
+addition to the logic changes in the handler.
 
 The end result should look like this:
 
@@ -100,10 +116,13 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Zend\Diactoros\Response\HtmlResponse;
+use Zend\Diactoros\Response\RedirectResponse;           // add this line
 use Zend\Expressive\Template\TemplateRendererInterface;
 
 class LoginHandler implements RequestHandlerInterface
 {
+    private const REDIRECT_ATTRIBUTE = 'authentication:redirect';
+
     /**
      * @var TemplateRendererInterface
      */
@@ -120,21 +139,26 @@ class LoginHandler implements RequestHandlerInterface
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
         $session = $request->getAttribute('session');
-        $redirect = $session->get('authentication:redirect');
+        $redirect = $session->get(self::REDIRECT_ATTRIBUTE);
 
         if (! $redirect) {
             $redirect = $request->getHeaderLine('Referer');
             if (in_array($redirect, ['', '/login'], true)) {
                 $redirect = '/';
             }
-            $session->set('authentication:redirect', $redirect);
         }
 
+        if ('POST' === $request->getMethod()) {
+            // Successful login; redirect to original page.
+            $session->unset(self::REDIRECT_ATTRIBUTE);
+            return new RedirectResponse($redirect);
+        }
+
+        // Requesting login
+        $session->set(self::REDIRECT_ATTRIBUTE, $redirect);
         return new HtmlResponse($this->renderer->render(
             'app::login',
-            [
-                'action' => $redirect,
-            ]
+            []
         ));
     }
 }
@@ -144,8 +168,10 @@ With these changes in place, our handler is now ready.
 
 ## Create the route
 
-From here, we need to create a route for the new handler. We will open up our
-`config/routes.php` file, and edit it to add the following within its callback:
+From here, we need to create two routes for the new handler, one to handle the
+incoming `GET` request for displaying the form, and the second to handle `POST`
+requests for validating the credentials. Open up your `config/routes.php` file,
+and edit it to add the following within its callback:
 
 ```php
 $app->get(
@@ -156,30 +182,62 @@ $app->get(
     ],
     'login'
 );
+$app->post(
+    '/login',
+    [
+        Zend\Expressive\Session\SessionMiddleware::class,
+        Zend\Expressive\Authentication\AuthenticationMiddleware::class,
+        App\Login\LoginHandler::class,
+    ]
+);
 ```
 
 Let's unpack the above a bit.
 
-First, we are creating a route that will respond to a `GET` request only.
+First, we create a route that will respond to a `GET` request only. This
+one contains only the session middleware and our handler. We need the session
+middleware so that we have the session container available in our handler, for
+the purpose of retrieving and setting our redirect URI.
 
-Second, we tell it to respond to the `/login` path, as we configured in the
-previous chapter.
+Second, we create a route that handles the `POST` request. This one sandwiches
+the `AuthenticationMiddleware` between the session middleware and our login
+handler.
 
-Third, for the middleware, we are providing a _pipeline_. The first middleware
-listed is the zend-expressive-session `SessionMiddleware`. This is required so
-that we have a session available to which to write the user when authenticated,
-but also so we can write and retrieve the referer redirect in our handler! The
-second item in the pipeline is the handler we've written above.
+Why two separate routes?
+
+When the `AuthenticationMiddleware` handles a request,
+it calls on the adapter to authenticate the request. The adapter then returns
+either a `UserInterface` instance, or `null`. In the latter case, the middleware
+then produces an "unauthorized response", which is in turn generated by the
+adapter. The `PhpSession` adapter redirects to the configured login URL at this
+point.
+
+As such, if we did a single route that handled both `GET` and `POST` requests,
+we would end up in an infinite redirect loop situation the first time we
+requested the login page, as we'd never have an authenticated user!
+
+When we do a `POST` request, if authentication fails, it redirects to the login
+page. However, if it succeeds, it continues on to the next handler. This is why
+the handler checks to see if it was requested via `POST`, and redirects to the
+original page when that condition occurs.
+
+In each case, we are specifiying a _pipeline_ for the handler. This approach
+allows us to only include the session and/or authentication middleware where its
+needed. In the case of the `PhpSession` adapter provided by this package, we
+need to _always_ include the `SessionMiddleware` in any pipeline where we are
+checking for an authenticated user, as the adapter will query the session for a
+user.
 
 With this in place, any routes we write that require authentication will now:
 
 - Redirect to the `/login` page, which will require that:
-- A user provides credentials and submits the form to the originally requested
-  URL, which will:
+- A user provides credentials and submits the form back to the `/login` page,
+  which will:
 - Allow the `PhpSession` adapter to validate the credentials and store the user
   details in the session, and:
 - Ultimately give them access (assuming any roles associated with them are
-  authorized).
+  authorized), and:
+- Redirect them back to the originally requested page.
 
 In the next chapter, we will [detail how to require authentication for
 individual handlers](requiring-authentication.md).

--- a/docs/book/v1/login-handler.md
+++ b/docs/book/v1/login-handler.md
@@ -66,11 +66,11 @@ PlatesPHP as noted earlier. As such, we will update the template in
         <div class="col-sm"><form action="<?= $action ?>" method="post">
             <div class="form-group">
                 <label for="username">Username</label>
-                <input type="text" class="form-control" id="username" placeholder="Enter username">
+                <input type="text" class="form-control" id="username" name="username" placeholder="Enter username">
             </div>
             <div class="form-group">
                 <label for="password">Password</label>
-                <input type="password" class="form-control" id="password" placeholder="Password">
+                <input type="password" class="form-control" id="password" name="password" placeholder="Password">
             </div>
             <button type="submit" class="btn btn-primary">Submit</button>
         </form></div>
@@ -148,14 +148,14 @@ From here, we need to create a route for the new handler. We will open up our
 `config/routes.php` file, and edit it to add the following within its callback:
 
 ```php
-    $app->get(
-        '/login',
-        [
-            Zend\Expressive\Session\SessionMiddleware::class,
-            App\Login\LoginHandler::class,
-        ],
-        'login'
-    );
+$app->get(
+    '/login',
+    [
+        Zend\Expressive\Session\SessionMiddleware::class,
+        App\Login\LoginHandler::class,
+    ],
+    'login'
+);
 ```
 
 Let's unpack the above a bit.

--- a/docs/book/v1/login-handler.md
+++ b/docs/book/v1/login-handler.md
@@ -1,0 +1,185 @@
+# Handling an initial login
+
+When you have configured the adapter, you can drop in the
+zend-expressive-authentication `AuthenticationMiddleware` anywhere you need to
+ensure you have an authenticated user. However, how do you handle the initial
+authentication?
+
+In the [previous chapter](config.md), we indicated that you need to configure a
+path to which to redirect when the adapter does not detect a user. In this
+chapter, we'll detail how to create a handler for getting these details, as well
+as how to set up routing for it.
+
+Roughly, the steps are:
+
+- Create a handler that will display a form, directing it to the originally
+  requested location.
+- Create a template with a form for capturing the username and password, with
+  the form action set to the originally requested location.
+- Create a route to the new handler.
+
+## Create the handler
+
+We will use the [zend-expressive CLI tooling](https://docs.zendframework.com/zend-expressive/v3/reference/cli-tooling)
+to generate our handler, as well as the related factory and template:
+
+```bash
+$ ./vendor/bin/expressive handler:create "App\Login\LoginHandler"
+```
+
+By default, if you have a configured template engine, this will do the
+following:
+
+- Create the handler for you.
+- Create logic in the handler to render a template and return the contents in
+  a response.
+- Create a factory for the handler.
+- Create a template for you in an appropriate directory.
+
+When it does these things, it provides you with the paths to each as well. In
+our case, we are using the [PlatesPHP templating
+integration](https://docs.zendframework.com/zend-expressive/v3/features/template/plates/),
+with a flat application structure, and the following files were either created
+or updated:
+
+- `src/App/Login/LoginHandler.php`, which contains the handler class itself.
+- `src/App/Login/LoginHandlerFactory.php`, which contains the factory for the handler.
+- `config/autoload/zend-expressive-tooling-factories.global.php`, which maps the
+  handler to its factory for the DI container.
+- `templates/app/login.phtml`, which contains our template.
+
+## Edit the template
+
+We will now edit the template. The main considerations are:
+
+- It needs to have a form that submits back to a URL provided to the template.
+- The form needs both a `username` and a `password` field.
+
+Our application is built off the skeleton, and so we are currently using
+[Bootstrap](https://getbootstrap.com) for a UI framework. We are also using
+PlatesPHP as noted earlier. As such, we will update the template in
+`templates/app/login.phtml` to read as follows:
+
+```php
+<div class="container">
+    <div class="row">
+        <div class="col-sm"><form action="<?= $action ?>" method="post">
+            <div class="form-group">
+                <label for="username">Username</label>
+                <input type="text" class="form-control" id="username" placeholder="Enter username">
+            </div>
+            <div class="form-group">
+                <label for="password">Password</label>
+                <input type="password" class="form-control" id="password" placeholder="Password">
+            </div>
+            <button type="submit" class="btn btn-primary">Submit</button>
+        </form></div>
+    </div>
+</div>
+```
+
+## Complete the handler
+
+The generated handler will mostly work for our needs. However, we need to modify
+it to do the following:
+
+- Grab the session container.
+- Attempt to grab a redirect URI from the session.
+- If one is not available:
+  - Check the `Referer` request header
+  - If the header is empty, or points to the login page, use the home page.
+  - Store the value in the session.
+- Pass the redirect URI to the template engine.
+
+The end result should look like this:
+
+```php
+namespace App\Login;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Zend\Diactoros\Response\HtmlResponse;
+use Zend\Expressive\Template\TemplateRendererInterface;
+
+class LoginHandler implements RequestHandlerInterface
+{
+    /**
+     * @var TemplateRendererInterface
+     */
+    private $renderer;
+
+    public function __construct(TemplateRendererInterface $renderer)
+    {
+        $this->renderer = $renderer;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function handle(ServerRequestInterface $request) : ResponseInterface
+    {
+        $session = $request->getAttribute('session');
+        $redirect = $session->get('authentication:redirect');
+
+        if (! $redirect) {
+            $redirect = $request->getHeaderLine('Referer');
+            if (in_array($redirect, ['', '/login'], true)) {
+                $redirect = '/';
+            }
+            $session->set('authentication:redirect', $redirect);
+        }
+
+        return new HtmlResponse($this->renderer->render(
+            'app::login',
+            [
+                'action' => $redirect,
+            ]
+        ));
+    }
+}
+```
+
+With these changes in place, our handler is now ready.
+
+## Create the route
+
+From here, we need to create a route for the new handler. We will open up our
+`config/routes.php` file, and edit it to add the following within its callback:
+
+```php
+    $app->get(
+        '/login',
+        [
+            Zend\Expressive\Session\SessionMiddleware::class,
+            App\Login\LoginHandler::class,
+        ],
+        'login'
+    );
+```
+
+Let's unpack the above a bit.
+
+First, we are creating a route that will respond to a `GET` request only.
+
+Second, we tell it to respond to the `/login` path, as we configured in the
+previous chapter.
+
+Third, for the middleware, we are providing a _pipeline_. The first middleware
+listed is the zend-expressive-session `SessionMiddleware`. This is required so
+that we have a session available to which to write the user when authenticated,
+but also so we can write and retrieve the referer redirect in our handler! The
+second item in the pipeline is the handler we've written above.
+
+With this in place, any routes we write that require authentication will now:
+
+- Redirect to the `/login` page, which will require that:
+- A user provides credentials and submits the form to the originally requested
+  URL, which will:
+- Allow the `PhpSession` adapter to validate the credentials and store the user
+  details in the session, and:
+- Ultimately give them access (assuming any roles associated with them are
+  authorized).
+
+In the next chapter, we will [detail how to require authentication for
+individual handlers](requiring-authentication.md).

--- a/docs/book/v1/login-handler.md
+++ b/docs/book/v1/login-handler.md
@@ -10,10 +10,10 @@ path to which to redirect when the adapter does not detect a user. In this
 chapter, we'll detail how to create a handler for getting these details, as well
 as how to set up routing for it.
 
-Roughly, the steps are:
+Roughly, what we need to do is:
 
-- Create a handler that will display a form, directing it to the originally
-  requested location.
+- Create a handler that will both display and handle a login form, redirecting
+  to the originally requested location once a successful authentication occurs.
 - Create a template with a form for capturing the username and password, with
   the form action set to the originally requested location.
 - Create a route to the new handler.
@@ -48,12 +48,132 @@ or updated:
   handler to its factory for the DI container.
 - `templates/app/login.phtml`, which contains our template.
 
+Now that we have created the handler, we can edit it to do the work we need.
+
+Our handler will react to two different HTTP methods.
+
+For an initial login request, the `GET` method will be used, and we will need to
+display our template. When we do, we will also memoize the originally requested
+URI, which will be available in the `Referer` header.
+
+When the user submits the form, it will be via the `POST` method. When this
+happens, we will need to validate the submitted credentials; we will do this
+using the `PhpSession` adapter from this package. If login is successful, we
+will redirect to the originally requested URI, using the value we previously
+stored in our session. If login fails, we will display our template, adding an
+error message indicating the credentials were invalid.
+
+The generated handler will already compose the `TemplateRendererInterface`, and
+render a template. We will need to add a constructor dependency on the
+`PhpSession` adapter, and store that value in a property. Additionally, since we
+will be performing a redirect for successful POST requests, we will need to add
+a requirement on `Zend\Diactoros\Response\RedirectResponse` in addition to the
+logic changes in the handler.
+
+The end result should look like this:
+
+```php
+namespace App\Login;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Zend\Diactoros\Response\HtmlResponse;
+use Zend\Diactoros\Response\RedirectResponse;           // add this line
+use Zend\Expressive\Authentication\Session\PhpSession;  // add this line
+use Zend\Expressive\Session\SessionInterface;           // add this line
+use Zend\Expressive\Template\TemplateRendererInterface;
+
+class LoginHandler implements RequestHandlerInterface
+{
+    private const REDIRECT_ATTRIBUTE = 'authentication:redirect';
+
+    /** @var PhpSession */
+    private $adapter;
+
+    /** @var TemplateRendererInterface */
+    private $renderer;
+
+    public function __construct(TemplateRendererInterface $renderer, PhpSession $adapter)
+    {
+        $this->renderer = $renderer;
+        $this->adapter = $adapter;
+    }
+
+    public function handle(ServerRequestInterface $request) : ResponseInterface
+    {
+        $session  = $request->getAttribute('session');
+        $redirect = $this->getRedirect($request, $session);
+
+        // Handle submitted credentials
+        if ('POST' === $request->getMethod()) {
+            return $this->handleLoginAttempt($request, $session, $redirect);
+        }
+
+        // Display initial login form
+        $session->set(self::REDIRECT_ATTRIBUTE, $redirect);
+        return new HtmlResponse($this->renderer->render(
+            'app::login',
+            []
+        ));
+    }
+
+    private function getRedirect(
+        ServerRequestInterface $request,
+        SessionInterface $session
+    ) : string {
+        $redirect = $session->get(self::REDIRECT_ATTRIBUTE);
+
+        if (! $redirect) {
+            $redirect = $request->getHeaderLine('Referer');
+            if (in_array($redirect, ['', '/login'], true)) {
+                $redirect = '/';
+            }
+        }
+
+        return $redirect;
+    }
+
+    private function handleLoginAttempt(
+        ServerRequestInterface $request,
+        SessionInterface $session,
+        string $redirect
+    ) : ResponseInterface {
+        // Login was successful
+        if ($this->adapter->authenticate($request)) {
+            $session->unset(self::REDIRECT_ATTRIBUTE);
+            return new RedirectResponse($redirect);
+        }
+
+        // Login failed
+        return new HtmlResponse($this->renderer->render(
+            'app::login',
+            ['error' => 'Invalid credentials; please try again']
+        ));
+    }
+}
+```
+
+With these changes in place, our handler is now ready. However, we need to
+update our factory, as we've added a new dependency!
+
+To do this, do the following from the command line, in the project root
+directory:
+
+```bash
+$ rm src/App/Login/LoginHandlerFactory.php
+$ ./vendor/bin/expressive factory:create "App\Login\LoginHandler"
+```
+
+This will regenerate the factory for you.
+
 ## Edit the template
 
 We will now edit the template. The main considerations are:
 
 - It needs to have a form that submits back to the login page.
 - The form needs both a `username` and a `password` field.
+- We need to display an error message if one was provided.
 
 Our application is built off the skeleton, and so we are currently using
 [Bootstrap](https://getbootstrap.com) for a UI framework. We are also using
@@ -64,6 +184,11 @@ PlatesPHP as noted earlier. As such, we will update the template in
 <div class="container">
     <div class="row">
         <div class="col-sm"><form action="<?= $this->url('login') ?>" method="post">
+            <?php if (isset($error)) : ?>
+            <div class="alert alert-danger" role="alert">
+                <?= $this->escapeHtml($error) ?>
+            </div>
+            <?php endif ?>
             <div class="form-group">
                 <label for="username">Username</label>
                 <input type="text" class="form-control" id="username" name="username" placeholder="Enter username">
@@ -78,163 +203,52 @@ PlatesPHP as noted earlier. As such, we will update the template in
 </div>
 ```
 
-## Complete the handler
-
-Our handler will react to two different HTTP methods. For an initial login
-request, the `GET` method will be used, and we will need to display our
-template. When the user submits the form, it will be via the `POST` method. In
-this situation, if the credentials are invalid, the `PhpSession` adapter will
-redirect to the login page again, via a `GET`. However, if it is successful, it
-will continue to the handler; at this point, we will want to redirect to the
-original page that needed an authenticated user.
-
-The generated handler will mostly work for our needs. However, we need to modify
-it to do the following:
-
-- Grab the session container.
-- Attempt to grab a redirect URI from the session.
-- If one is not available:
-  - Check the `Referer` request header
-  - If the header is empty, or points to the login page, use the home page.
-- If this is a POST request:
-  - Remove the redirect URI from the session.
-  - Redirect to the redirect URI.
-- If this is a GET request:
-  - Store the redirect URI in the session.
-  - Pass the redirect URI to the template engine.
-
-Since we will be performing a redirect for successful POST requests, we will
-need to add a requirement on `Zend\Diactoros\Response\RedirectResponse` in
-addition to the logic changes in the handler.
-
-The end result should look like this:
-
-```php
-namespace App\Login;
-
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Diactoros\Response\HtmlResponse;
-use Zend\Diactoros\Response\RedirectResponse;           // add this line
-use Zend\Expressive\Template\TemplateRendererInterface;
-
-class LoginHandler implements RequestHandlerInterface
-{
-    private const REDIRECT_ATTRIBUTE = 'authentication:redirect';
-
-    /**
-     * @var TemplateRendererInterface
-     */
-    private $renderer;
-
-    public function __construct(TemplateRendererInterface $renderer)
-    {
-        $this->renderer = $renderer;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function handle(ServerRequestInterface $request) : ResponseInterface
-    {
-        $session = $request->getAttribute('session');
-        $redirect = $session->get(self::REDIRECT_ATTRIBUTE);
-
-        if (! $redirect) {
-            $redirect = $request->getHeaderLine('Referer');
-            if (in_array($redirect, ['', '/login'], true)) {
-                $redirect = '/';
-            }
-        }
-
-        if ('POST' === $request->getMethod()) {
-            // Successful login; redirect to original page.
-            $session->unset(self::REDIRECT_ATTRIBUTE);
-            return new RedirectResponse($redirect);
-        }
-
-        // Requesting login
-        $session->set(self::REDIRECT_ATTRIBUTE, $redirect);
-        return new HtmlResponse($this->renderer->render(
-            'app::login',
-            []
-        ));
-    }
-}
-```
-
-With these changes in place, our handler is now ready.
-
 ## Create the route
 
-From here, we need to create two routes for the new handler, one to handle the
-incoming `GET` request for displaying the form, and the second to handle `POST`
-requests for validating the credentials. Open up your `config/routes.php` file,
-and edit it to add the following within its callback:
+From here, we need to create a route for the new handler that handles two HTTP
+methods: `GET` for displaying the initial form, and `POST` for validating
+submitted credentials. Open up your `config/routes.php` file, and edit it to add
+the following within its callback:
 
 ```php
-$app->get(
+$app->route(
     '/login',
     [
         Zend\Expressive\Session\SessionMiddleware::class,
         App\Login\LoginHandler::class,
     ],
+    ['GET', 'POST'],
     'login'
-);
-$app->post(
-    '/login',
-    [
-        Zend\Expressive\Session\SessionMiddleware::class,
-        Zend\Expressive\Authentication\AuthenticationMiddleware::class,
-        App\Login\LoginHandler::class,
-    ]
 );
 ```
 
 Let's unpack the above a bit.
 
-First, we create a route that will respond to a `GET` request only. This
-one contains only the session middleware and our handler. We need the session
-middleware so that we have the session container available in our handler, for
-the purpose of retrieving and setting our redirect URI.
+First, we are using the `route()` method, as we want to create a _single_ route
+to respond to _multiple_ HTTP methods. This method has a required third argument,
+which is an array of HTTP methods; we specify `GET` and `POST` in this array.
 
-Second, we create a route that handles the `POST` request. This one sandwiches
-the `AuthenticationMiddleware` between the session middleware and our login
-handler.
+Second, we are indicating that we want the route to respond to the exact path
+`/login`; we provide this via the initial method argument.
 
-Why two separate routes?
+Third, we are providing a name for this route via the optional fourth argument;
+this is what allows us to call `$this->url('login')` in our template in order to
+generate the URL to the login page.
 
-When the `AuthenticationMiddleware` handles a request,
-it calls on the adapter to authenticate the request. The adapter then returns
-either a `UserInterface` instance, or `null`. In the latter case, the middleware
-then produces an "unauthorized response", which is in turn generated by the
-adapter. The `PhpSession` adapter redirects to the configured login URL at this
-point.
-
-As such, if we did a single route that handled both `GET` and `POST` requests,
-we would end up in an infinite redirect loop situation the first time we
-requested the login page, as we'd never have an authenticated user!
-
-When we do a `POST` request, if authentication fails, it redirects to the login
-page. However, if it succeeds, it continues on to the next handler. This is why
-the handler checks to see if it was requested via `POST`, and redirects to the
-original page when that condition occurs.
-
-In each case, we are specifiying a _pipeline_ for the handler. This approach
-allows us to only include the session and/or authentication middleware where its
-needed. In the case of the `PhpSession` adapter provided by this package, we
-need to _always_ include the `SessionMiddleware` in any pipeline where we are
-checking for an authenticated user, as the adapter will query the session for a
-user.
+Finally, for the middleware argument, we are providing a [pipeline](https://docs.zendframework.com/zend-expressive/v1/getting-started/features/#pipelines),
+by providing an _array_ of middleware to execute. The first item in the pipeline
+is the `SessionMiddleware` from zend-expressive-session; this is required to
+ensure we have a session container injected into the request. The second item is
+our login handler itself, which will then do the actual work of creating a
+response.
 
 With this in place, any routes we write that require authentication will now:
 
 - Redirect to the `/login` page, which will require that:
 - A user provides credentials and submits the form back to the `/login` page,
   which will:
-- Allow the `PhpSession` adapter to validate the credentials and store the user
-  details in the session, and:
+- Process the credentials via the `PhpSession` adapter, which will store
+  identified user details in the session, and:
 - Ultimately give them access (assuming any roles associated with them are
   authorized), and:
 - Redirect them back to the originally requested page.

--- a/docs/book/v1/requiring-authentication.md
+++ b/docs/book/v1/requiring-authentication.md
@@ -1,0 +1,99 @@
+# Configuring Handlers To Require Authentication
+
+In the [previous chapter](login-handler.md), we detailed writing a handler to
+display a login form for submitting credentials. That handler has the form post
+to the original URL in order to validate the credentials.
+
+This means that the original handler needs to have the
+`AuthenticationMiddleware` as part of its pipeline.
+
+Additionally, this package depends on the zend-expressive-session
+`SessionMiddleware` being present and in the pipeline before the
+zend-expressive-authentication `AuthenticationMiddleware`, as the `PhpSession`
+adapter it provides requires access to the session container via the request.
+
+There are three ways to accomplish this:
+
+- Requiring authentication everywhere.
+- Requiring authentication for subpaths of the application.
+- Requiring authentication for individual routes.
+
+## Requiring authentication everywhere
+
+With this approach, every request other than the one to the login form itself
+will require authentication. To make this possible, you will need to decorate
+the zend-expressive-authentication `AuthenticationMiddleware` so that you can
+exclude that particular path.
+
+As an example, you could do the following in the `config/pipeline.php` file,
+before the `RouteMiddleware` somewhere:
+
+```php
+// Pipe in the session middleware
+$app->pipe(Zend\Expressive\Session\SessionMiddleware::class);
+
+// Grab the authentication middleware, and then decorate it when piping it to
+// the application:
+$authenticationMiddleware = $container->get(
+    Zend\Expressive\Authentication\AuthenticationMiddleware::class
+);
+$app->pipe($factory->callable(
+    function ($request, $handler) use ($authenticationMiddleware) {
+        if ($request->getUri()->getPath() === '/login') {
+            return $handler->handle($request);
+        }
+
+        return $authenticationMiddleware->process($request, $handler);
+    }
+));
+```
+
+## Requiring authentication for subpaths of the application
+
+If you know all handlers under a given subpath of the application require
+authentication, you can use Stratigility's [path segregation features](https://docs.zendframework.com/zend-stratigility/v3/api/#path)
+to add authentication.
+
+For example, consider the following within the `config/pipeline.php` file, which
+adds authentication to any path starting with `/admin`:
+
+```php
+// Add this within the import section of the file:
+use function Zend\Stratigility\path;
+
+// Add this within the callback, before the routing middleware:
+$app->pipe(path('/admin', $factory->pipeline(
+    Zend\Expressive\Session\SessionMiddleware::class,
+    Zend\Expressive\Authentication\AuthenticationMiddleware::class,
+)));
+```
+
+## Requiring authentication for individual routes
+
+The most granular approach involves adding authentication to individual routes.
+In such cases, you will create a [route-specific middleware
+pipeline](https://docs.zendframework.com/zend-expressive/v3/cookbook/route-specific-pipeline/).
+
+As an example, if we wanted authentication for each of the routes that use the
+path `/admin/users[/\d+]`, we could do the following within our
+`config/routes.php` file:
+
+```php
+$app->get('/admin/users[/\d+]', [
+    Zend\Expressive\Session\SessionMiddleware::class,
+    Zend\Expressive\Authentication\AuthenticationMiddleware::class,
+    App\Users\UsersHandler::class,
+], 'users');
+$app->post('/admin/users', [
+    Zend\Expressive\Session\SessionMiddleware::class,
+    Zend\Expressive\Authentication\AuthenticationMiddleware::class,
+    App\Users\CreateUserHandler::class,
+]);
+$app->post('/admin/users[/\d+]', [
+    Zend\Expressive\Session\SessionMiddleware::class,
+    Zend\Expressive\Authentication\AuthenticationMiddleware::class,
+    App\Users\UpdateUserHandler::class,
+]);
+```
+
+Note that each pipeline contains both the session and authentication middleware!

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 docs_dir: docs/book
 site_dir: docs/html
 pages:
-    - index.md
+    - Home: index.md
     - Introduction: v1/intro.md
     - Tutorial:
       - Configuration: v1/config.md
@@ -12,4 +12,3 @@ pages:
 site_name: zend-expressive-authentication-session
 site_description: 'Username/password, session-backed authentication adapter for zend-expressive-authentication.'
 repo_url: 'https://github.com/zendframework/zend-expressive-authentication-session'
-copyright: 'Copyright (c) 2017-2018 <a href="http://www.zend.com/">Zend Technologies USA Inc.</a>'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,8 +2,14 @@ docs_dir: docs/book
 site_dir: docs/html
 pages:
     - index.md
-    - Introduction: intro.md
+    - Introduction: v1/intro.md
+    - Tutorial:
+      - Configuration: v1/config.md
+      - "Login Handlers": v1/login-handler.md
+      - "Handlers Requiring Authentication": v1/requiring-authentication.md
+    - "_hidden-legacy-page-links":
+      - "_intro": intro.md
 site_name: zend-expressive-authentication-session
 site_description: 'Username/password, session-backed authentication adapter for zend-expressive-authentication.'
 repo_url: 'https://github.com/zendframework/zend-expressive-authentication-session'
-copyright: 'Copyright (c) 2017 <a href="http://www.zend.com/">Zend Technologies USA Inc.</a>'
+copyright: 'Copyright (c) 2017-2018 <a href="http://www.zend.com/">Zend Technologies USA Inc.</a>'

--- a/src/PhpSession.php
+++ b/src/PhpSession.php
@@ -71,7 +71,6 @@ class PhpSession implements AuthenticationInterface
 
     /**
      * {@inheritDoc}
-     * @todo Refactor to use zend-expressive-session
      */
     public function authenticate(ServerRequestInterface $request) : ?UserInterface
     {

--- a/src/PhpSession.php
+++ b/src/PhpSession.php
@@ -13,6 +13,7 @@ namespace Zend\Expressive\Authentication\Session;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Traversable;
 use Zend\Expressive\Authentication\AuthenticationInterface;
 use Zend\Expressive\Authentication\UserInterface;
 use Zend\Expressive\Authentication\UserRepositoryInterface;
@@ -102,7 +103,7 @@ class PhpSession implements AuthenticationInterface
         if (null !== $user) {
             $session->set(UserInterface::class, [
                 'username' => $user->getIdentity(),
-                'roles'    => $user->getRoles(),
+                'roles'    => iterator_to_array($this->getUserRoles($user)),
                 'details'  => $user->getDetails(),
             ]);
             $session->regenerate();
@@ -138,5 +139,13 @@ class PhpSession implements AuthenticationInterface
         $details = $userInfo['details'] ?? [];
 
         return ($this->userFactory)($userInfo['username'], (array) $roles, (array) $details);
+    }
+
+    /**
+     * Convert the iterable user roles to a Traversable.
+     */
+    private function getUserRoles(UserInterface $user) : Traversable
+    {
+        return yield from $user->getRoles();
     }
 }


### PR DESCRIPTION
This patch accomplishes two things:

- It updates the zend-expressive-authentication requirement to `^1.0`. All tests continue to pass as-is.
- It fleshes out the documentation to detail how to configure the package, add a login handler, and add authentication to an existing application (as it requires both the session and authentication middleware).

Fixes #17
Supercedes #18